### PR TITLE
Update to ASP.NET Core 2.1.1

### DIFF
--- a/samples/AspNetCoreWebApplication/AspNetCoreWebApplication.csproj
+++ b/samples/AspNetCoreWebApplication/AspNetCoreWebApplication.csproj
@@ -1,13 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />
   </ItemGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.1" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\HybridModelBinding\HybridModelBinding.csproj" />

--- a/samples/AspNetCoreWebApplication/Pages/Error.cshtml
+++ b/samples/AspNetCoreWebApplication/Pages/Error.cshtml
@@ -1,5 +1,5 @@
 ﻿@page
-@model ErrorModel
+@model AspNetCoreWebApplication.Pages.ErrorModel
 @{
     ViewData["Title"] = "Error";
 }

--- a/samples/AspNetCoreWebApplication/Pages/Error.cshtml.cs
+++ b/samples/AspNetCoreWebApplication/Pages/Error.cshtml.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Diagnostics;
 
 namespace AspNetCoreWebApplication.Pages
 {

--- a/samples/AspNetCoreWebApplication/Program.cs
+++ b/samples/AspNetCoreWebApplication/Program.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore;
+﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace AspNetCoreWebApplication
 {

--- a/samples/AspNetCoreWebApplication/Startup.cs
+++ b/samples/AspNetCoreWebApplication/Startup.cs
@@ -2,7 +2,7 @@ using HybridModelBinding;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/HybridModelBinding/DefaultHybridModelBinder.cs
+++ b/src/HybridModelBinding/DefaultHybridModelBinder.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc.Formatters;
-using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 using System.Collections.Generic;

--- a/src/HybridModelBinding/DefaultHybridModelBinderProvider.cs
+++ b/src/HybridModelBinding/DefaultHybridModelBinderProvider.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc.Formatters;
-using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using System.Collections.Generic;
 
 namespace HybridModelBinding

--- a/src/HybridModelBinding/DefaultPassthroughHybridModelBinder.cs
+++ b/src/HybridModelBinding/DefaultPassthroughHybridModelBinder.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc.Formatters;
-using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 using System.Collections.Generic;

--- a/src/HybridModelBinding/DefaultPassthroughHybridModelBinderProvider.cs
+++ b/src/HybridModelBinding/DefaultPassthroughHybridModelBinderProvider.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc.Formatters;
-using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using System.Collections.Generic;
 
 namespace HybridModelBinding

--- a/src/HybridModelBinding/HybridModelBinding.csproj
+++ b/src/HybridModelBinding/HybridModelBinding.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version=" 2.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes issues with previous commits that updated libary, but sample project was on an older version of the Core runtime. There are breaking changes between the minor versions.

Implements https://github.com/billbogaiv/hybrid-model-binding/issues/11