### PR TITLE
Update default model behavior

### DIFF
--- a/src/HybridModelBinding/HybridModelBinding.csproj
+++ b/src/HybridModelBinding/HybridModelBinding.csproj
@@ -13,6 +13,8 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>0.9.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HybridModelBinding/Source.cs
+++ b/src/HybridModelBinding/Source.cs
@@ -2,9 +2,9 @@
 {
     public static class Source
     {
-        public const string Body = "body";
-        public const string Form = "form";
-        public const string QueryString = "query";
-        public const string Route = "route";
+        public const string Body = nameof(Body);
+        public const string Form = nameof(Form);
+        public const string QueryString = nameof(QueryString);
+        public const string Route = nameof(Route);
     }
 }


### PR DESCRIPTION
Previous behavior would use the default-value of a property's type on the model when no binding took place on the property.
However, this negates a model that has set a default-value for the property.

New behavior is a temporary shim to get the expected behavior while leaving a breadcrumb for an idea to compare the "hydrated" model against a plain "new-instance" of the model.