### PR TITLE
Add HybridPropertyAttribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
-# HybridModelBinding
+﻿# HybridModelBinding
 
 *For those who want the utmost flexibility in model binding.*
 
-**Note: this README is a [WIP](http://stackoverflow.com/a/15763080).**
-
-The hybrid approach differs from traditional model binding since you get to work with both `IModelBinder` and `IValueProvider`. This means your model can first get bound with data from the body of a request, and then potentially get updated with data from route or querystring-attributes (in that order). This has the most benefit for users who prefer to have one-model for their request representations. **To avoid unexpected model-values, value providers by default, are not bound unless the model's properties are properly attribute-decorated.**
+The hybrid approach differs from traditional model binding since you get to work with both `IModelBinder` and `IValueProvider`. This means your model can first get bound with data from the body of a request, and then potentially get updated with data from route or querystring-attributes (in that order). This has the most benefit for users who prefer to have one-model for their request representations.
 
 ## Examples
 
-### ASP.NET Core 2.1
+### ASP.NET Core 2.2
 
 ```shell
 dotnet add package HybridModelBinding
@@ -23,12 +21,67 @@ dotnet add package HybridModelBinding
 public void ConfigureServices(IServiceCollection services)
 {
     // Add framework services.
-    services.AddMvc()
+    services
+        .AddMvc()
         .AddHybridModelBinder();
 }
 ```
 
 #### Model
+
+##### NEW WAY!
+
+(version 0.14.0+) New implementation will allow a bit more flexibility and expandability for future features.
+
+```csharp
+using HybridModelBinding;
+
+public class IndexModel
+{
+    [HybridBindProperty(new[] { Source.Header, Source.Body, Source.Form, Source.QueryString, Source.Route })]
+    public int? Age { get; set; }
+
+    /// <summary>
+    /// For this specific source, we want to bind to a header-key of `X-Name`.
+    /// Additionally, this has higher-precedence when looking for a binding-source.
+    /// </summary>
+    [HybridBindProperty(Source.Header, "X-Name")]
+
+    /// <summary>
+    /// These are bound using the source-key of `Name`.
+    /// </summary>
+    [HybridBindProperty(new[] { Source.Body, Source.Form, Source.QueryString, Source.Route })]
+    public string Name { get; set; }
+}
+```
+
+`HybridBindProperty` also allows specifying order. This is implicitly set based on the line-number of the attribute. It can also be explicitly set to avoid confusion:
+
+```csharp
+[HybridBindProperty(Source.Header, "X-Name", order: 5)]
+[HybridBindProperty(new[] { Source.Body, Source.Form, Source.QueryString, Source.Route }, order: 10)]
+public string Name { get; set; }
+```
+
+Declaring multiple attributes on the same line may cause unpredictable results and should be avoided (unless using explicit ordering):
+
+```csharp
+[HybridBindProperty(Source.Header, "X-Name")][HybridBindProperty(new[] { Source.Body, Source.Form, Source.QueryString, Source.Route })]
+public string Name { get; set; }
+```
+
+This way is also valid, but may look odd depending whether you read lists top-bottom or bottom-top. In this case, the `Source.Body...`-attribute is given higher priority.
+
+```csharp
+[HybridBindProperty(Source.Header, "X-Name", order: 10)]
+[HybridBindProperty(new[] { Source.Body, Source.Form, Source.QueryString, Source.Route }, order: 5)]
+public string Name { get; set; }
+```
+
+##### ⚠️ Obsolete way
+
+No specific timeline for complete removal, but `[From]` will **not** be getting updates.
+`[From]` and `[HybridBindProperty]` *can* be used together on the same property. Ordering rules will apply `[From]` first.
 
 ```csharp
 using HybridModelBinding;
@@ -60,7 +113,7 @@ public IActionResult Index(IndexModel model)
 <h3>Name: @(string.IsNullOrEmpty(Model.Name) ? "N/A" : Model.Name)</h3>
 ```
 
-By adding the convention-instance, any controller-action with one-parameter will automatically get associated with the hybrid binder. `DefaultHybridModelBinderProvider` is built-in and is setup to bind data in the following order: body => form-values => route-values => querystring-values. If you do not want to use the convention, you can also decorate your model-parameter with `[From]`.
+By adding the convention-instance, any controller-action with one-parameter will automatically get associated with the hybrid binder. `DefaultHybridModelBinderProvider` is built-in and is setup to bind data in the following order: body => form-values => route-values => querystring-values => header-values. If you do not want to use the convention, you can also decorate your model-parameter with `[From]`.
 
 ## Results
 
@@ -99,4 +152,17 @@ Based on the setup above, here is how various URIs will get parsed/rendered:
 ```html
 <h3>Age: 20</h3>
 <h3>Name: Bill</h3> <!--note how the querystring does not get bound since the route comes first in the [From...] ordering-->
+```
+
+### Example using headers and alternate-naming
+
+```curl
+curl -X GET \
+  http://localhost/10/Bill?name=Boga \
+  -H 'X-Name: Billy'
+  ```
+
+  ```html
+<h3>Age: 20</h3>
+<h3>Name: Billy</h3>
 ```

--- a/samples/AspNetCoreWebApplication/AspNetCoreWebApplication.csproj
+++ b/samples/AspNetCoreWebApplication/AspNetCoreWebApplication.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/AspNetCoreWebApplication/Models/IndexModel.cs
+++ b/samples/AspNetCoreWebApplication/Models/IndexModel.cs
@@ -4,10 +4,11 @@ namespace AspNetCoreWebApplication.Models
 {
     public class IndexModel
     {
-        [From(Source.Body, Source.QueryString, Source.Route)]
+        [From(Source.Header, Source.Body, Source.QueryString, Source.Route)]
         public int? Age { get; set; }
 
-        [From(Source.Body, Source.Form, Source.QueryString, Source.Route)]
+        [HybridBindProperty(Source.Header, "X-Name")]
+        [HybridBindProperty(new[] { Source.Body, Source.Form, Source.QueryString, Source.Route })]
         public string Name { get; set; }
     }
 }

--- a/samples/AspNetCoreWebApplication/Startup.cs
+++ b/samples/AspNetCoreWebApplication/Startup.cs
@@ -1,27 +1,18 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AspNetCoreWebApplication
 {
     public class Startup
     {
-        public Startup(IConfiguration configuration)
-        {
-            Configuration = configuration;
-        }
-
-        public IConfiguration Configuration { get; }
-
-        // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc()
+            services
+                .AddMvc()
                 .AddHybridModelBinder();
         }
 
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             if (env.IsDevelopment())

--- a/src/HybridModelBinding/FromAttribute.cs
+++ b/src/HybridModelBinding/FromAttribute.cs
@@ -2,9 +2,13 @@
 
 namespace HybridModelBinding
 {
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    [Obsolete("Use `" + nameof(HybridBindPropertyAttribute) + "` instead.")]
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
     public class FromAttribute : Attribute
     {
+        /// <summary>
+        /// Overall ordering with other usages of `HybridPropertyAttribute` is given priority.
+        /// </summary>
         public FromAttribute(params string[] valueProviders)
         {
             ValueProviders = valueProviders;
@@ -13,12 +17,7 @@ namespace HybridModelBinding
         protected FromAttribute(HybridModelBinder.BindStrategy strategy, params string[] valueProviders)
             : this(valueProviders)
         {
-            if (strategy == null)
-            {
-                throw new ArgumentNullException(nameof(strategy));
-            }
-
-            Strategy = strategy;
+            Strategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
         }
 
         public HybridModelBinder.BindStrategy Strategy { get; private set; }

--- a/src/HybridModelBinding/HybridBindPropertyAttribute.cs
+++ b/src/HybridModelBinding/HybridBindPropertyAttribute.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace HybridModelBinding
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+    public class HybridBindPropertyAttribute : Attribute
+    {
+        /// <param name="name">Provide alternate name within `valueProvider` to bind to this property.</param>
+        /// <param name="order">Provide explicit order of binding when matched with other usages of `HybridPropertyAttribute` on the same property.</param>
+        public HybridBindPropertyAttribute(
+            string valueProvider,
+            [CallerMemberName]string name = default(string),
+            [CallerLineNumber]int order = default(int))
+            : this(new[] { valueProvider }, name, order)
+        { }
+
+        /// <param name="name">Provide alternate name within all `valueProviders` to bind to this property.</param>
+        /// <param name="order">Provide explicit order of binding when matched with other usages of `HybridPropertyAttribute` on the same property.</param>
+        public HybridBindPropertyAttribute(
+            string[] valueProviders,
+            [CallerMemberName]string name = default(string),
+            [CallerLineNumber]int order = default(int))
+        {
+            ValueProviders = valueProviders;
+            Name = name;
+            Order = order;
+        }
+
+        /// <param name="name">Provide alternate name within all `valueProviders` to bind to this property.</param>
+        /// <param name="order">Provide explicit order of binding when matched with other usages of `HybridPropertyAttribute` on the same property.</param>
+        protected HybridBindPropertyAttribute(
+            HybridModelBinder.BindStrategy strategy,
+            string[] valueProviders,
+            [CallerMemberName]string name = default(string),
+            [CallerLineNumber]int order = default(int))
+            : this(valueProviders, name, order)
+        {
+            Strategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
+        }
+
+        public string Name { get; private set; }
+        public int? Order { get; private set; }
+        public HybridModelBinder.BindStrategy Strategy { get; private set; }
+        public string[] ValueProviders { get; private set; }
+    }
+}

--- a/src/HybridModelBinding/HybridModelBinding.csproj
+++ b/src/HybridModelBinding/HybridModelBinding.csproj
@@ -6,13 +6,13 @@
         <AssemblyName>HybridModelBinding</AssemblyName>
         <PackageId>HybridModelBinding</PackageId>
         <PackageTags>hybrid;modelbinder;valueprovider;asp.net core;mvc</PackageTags>
-        <PackageProjectUrl>https://github.com/billboga/hybrid-model-binding/</PackageProjectUrl>
-        <PackageLicenseUrl>https://raw.githubusercontent.com/billboga/hybrid-model-binding/master/LICENSE</PackageLicenseUrl>
+        <PackageProjectUrl>https://github.com/billbogaiv/hybrid-model-binding/</PackageProjectUrl>
+        <PackageLicenseUrl>https://raw.githubusercontent.com/billbogaiv/hybrid-model-binding/master/LICENSE</PackageLicenseUrl>
         <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
         <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
         <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>0.13.0</Version>
+        <Version>0.14.0</Version>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.1" />

--- a/src/HybridModelBinding/HybridMvcBuilderExtensions.cs
+++ b/src/HybridModelBinding/HybridMvcBuilderExtensions.cs
@@ -15,35 +15,43 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static IMvcBuilder AddHybridModelBinder(this IMvcBuilder builder)
         {
-            if (builder == null) throw new ArgumentNullException(nameof(builder));
+            builder = builder ?? throw new ArgumentNullException(nameof(builder));
 
-            return builder.AddMvcOptions(mvcOptions => mvcOptions.AddHybridModelBinder(builder.Services));
+            return builder.AddMvcOptions(mvcOptions => mvcOptions
+                .AddHybridModelBinder(builder.Services));
         }
 
-        public static IMvcBuilder AddHybridModelBinder(this IMvcBuilder builder,
+        public static IMvcBuilder AddHybridModelBinder(
+            this IMvcBuilder builder,
             Action<HybridModelBinderOptions> setupAction)
         {
-            if (builder == null) throw new ArgumentNullException(nameof(builder));
+            builder = builder ?? throw new ArgumentNullException(nameof(builder));
 
-            return builder.AddMvcOptions(mvcOptions => mvcOptions.AddHybridModelBinder(builder.Services, setupAction));
+            return builder.AddMvcOptions(mvcOptions => mvcOptions
+                .AddHybridModelBinder(builder.Services, setupAction));
         }
 
         public static IMvcCoreBuilder AddHybridModelBinder(this IMvcCoreBuilder builder)
         {
-            if (builder == null) throw new ArgumentNullException(nameof(builder));
+            builder = builder ?? throw new ArgumentNullException(nameof(builder));
 
-            return builder.AddMvcOptions(mvcOptions => mvcOptions.AddHybridModelBinder(builder.Services));
+            return builder.AddMvcOptions(mvcOptions => mvcOptions
+                .AddHybridModelBinder(builder.Services));
         }
 
-        public static IMvcCoreBuilder AddHybridModelBinder(this IMvcCoreBuilder builder,
+        public static IMvcCoreBuilder AddHybridModelBinder(
+            this IMvcCoreBuilder builder,
             Action<HybridModelBinderOptions> setupAction)
         {
-            if (builder == null) throw new ArgumentNullException(nameof(builder));
+            builder = builder ?? throw new ArgumentNullException(nameof(builder));
 
-            return builder.AddMvcOptions(mvcOptions => mvcOptions.AddHybridModelBinder(builder.Services, setupAction));
+            return builder.AddMvcOptions(mvcOptions => mvcOptions
+                .AddHybridModelBinder(builder.Services, setupAction));
         }
 
-        private static void AddHybridModelBinder(this MvcOptions mvcOptions, IServiceCollection services,
+        private static void AddHybridModelBinder(
+            this MvcOptions mvcOptions,
+            IServiceCollection services,
             Action<HybridModelBinderOptions> setupAction = null)
         {
             var options = new HybridModelBinderOptions();
@@ -56,9 +64,9 @@ namespace Microsoft.Extensions.DependencyInjection
             mvcOptions.Conventions.Add(hybridConvention);
 
             var provider = !options.Passthrough
-                ? (IModelBinderProvider) new DefaultHybridModelBinderProvider(mvcOptions.InputFormatters,
-                    readerFactory)
+                ? (IModelBinderProvider)new DefaultHybridModelBinderProvider(mvcOptions.InputFormatters, readerFactory)
                 : new DefaultPassthroughHybridModelBinderProvider(mvcOptions.InputFormatters, readerFactory);
+
             mvcOptions.ModelBinderProviders.Insert(0, provider);
         }
     }

--- a/src/HybridModelBinding/Strategy.cs
+++ b/src/HybridModelBinding/Strategy.cs
@@ -1,19 +1,20 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace HybridModelBinding
 {
     public static class Strategy
     {
         public static bool FirstInWins(
-            string[] previouslyBoundValueProviderIds,
-            string[] allValueProviderIds)
+            IEnumerable<string> previouslyBoundValueProviderIds,
+            IEnumerable<string> allValueProviderIds)
         {
             return !previouslyBoundValueProviderIds.Any();
         }
 
         public static bool Passthrough(
-            string[] previouslyBoundValueProviderIds,
-            string[] allValueProviderIds)
+            IEnumerable<string> previouslyBoundValueProviderIds,
+            IEnumerable<string> allValueProviderIds)
         {
             return true;
         }


### PR DESCRIPTION
New behavior allows more flexibility when declaring properties as part of hybrid binding ecosystem.
This includes allowing alternate valueProvider source-naming and ordering.
The former allows using a provider (i.e. Header) with a different key than the property-name (i.e. X-Name).
The latter allows implicit (via `CallerLineNumber`) and explicit-ordering based on the line the attribute is declared (declaring multiple attributes is now allowed).

Ref. https://github.com/billbogaiv/hybrid-model-binding/issues/23