### PR TITLE
Limit convention to instantiable classes

### DIFF
--- a/src/HybridModelBinding/HybridModelBinderApplicationModelConvention.cs
+++ b/src/HybridModelBinding/HybridModelBinderApplicationModelConvention.cs
@@ -22,6 +22,8 @@ namespace HybridModelBinding
                             .Any();
 
                         if (!hasBindingAttribute &&
+                            parameterType.IsClass &&
+                            !parameterType.IsAbstract &&
                             parameterType.GetProperties(BindingFlags.Public | BindingFlags.Instance).Count() > 0 &&
                             parameterType != typeof(string))
                         {

--- a/src/HybridModelBinding/HybridModelBinding.csproj
+++ b/src/HybridModelBinding/HybridModelBinding.csproj
@@ -12,7 +12,7 @@
         <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
         <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>0.14.0</Version>
+        <Version>0.15.0</Version>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.1" />


### PR DESCRIPTION
Previous behavior's rules would allow an action with one-parameter where the type is a non-class.
This would cause problems when the binder tried to instantiate the type and expect a non-null instance.

Implements https://github.com/billbogaiv/hybrid-model-binding/issues/28