### PR TITLE
Add ability to bind form-files

### DIFF
--- a/src/HybridModelBinding/HybridModelBinding.csproj
+++ b/src/HybridModelBinding/HybridModelBinding.csproj
@@ -12,7 +12,7 @@
         <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
         <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>0.15.0</Version>
+        <Version>0.16.0</Version>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.1" />


### PR DESCRIPTION
New behavior allows binding to instances of `IFormFile`. Current implementation allows for single and multiple files.
Might implement custom `TypeConverter` in the future.