### PR TITLE
Update build process

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,33 +8,31 @@ jobs:
       is_tag: ${{startsWith(github.ref, 'refs/tags') == true}}
     runs-on: windows-latest
     steps:
+      - name: Setup whether job needs to handle NuGet-packaging
+        id: needs_packaging
+        env:
+          needs_packaging: ${{env.is_master_branch == 'true' || env.is_release_branch == 'true' || env.is_tag_branch == 'true'}}
+        run: echo "::set-output name=value::$env:needs_packaging"
+
       - name: Checkout project
         uses: actions/checkout@v2
+
+      - name: Fetch history for versioning
+        if: steps.needs_packaging.outputs.value == 'true'
+        run: git fetch --prune --unshallow
+
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.100'
-      - name: Generate build-number
-        uses: einaregilsson/build-number@v2
-        with:
-          token: ${{secrets.GITHUB_TOKEN}}
-      - name: Setup version information
-        id: version
-        run: |
-          echo "::set-output name=prefix::$(type version.txt)"
-          echo "::set-output name=suffix::$(if ($env:is_tag -ne 'true') {$(if ($env:is_master_branch -eq 'true') {'alpha'} else {$(if ($env:is_release_branch -eq 'true') {'beta'} else {'build'})})+'-'+$env:BUILD_NUMBER} else {})"
+
       - name: Build project
-        run: dotnet build -c Release -f netstandard2.0 -p:VersionPrefix=${{steps.version.outputs.prefix}} -p:VersionSuffix=${{steps.version.outputs.suffix}} -o bin/ src/HybridModelBinding
+        run: dotnet build -c Release -f netstandard2.0 -o bin/ src/HybridModelBinding
+
       - name: Create NuGet-package
-        run: dotnet pack --no-build -p:VersionPrefix=${{steps.version.outputs.prefix}} -p:VersionSuffix=${{steps.version.outputs.suffix}} -p:OutputPath=../../bin/ src/HybridModelBinding
-      - name: Find NuGet package-name and make available to subsequent steps
-        id: nuget
-        run: echo "::set-output name=package_name::$(ls bin/*.nupkg | select -expandproperty name)"
-      - name: Upload NuGet-package artifact
-        uses: actions/upload-artifact@v1
-        with:
-          name: package
-          path: bin/${{steps.nuget.outputs.package_name}}
+        if: steps.needs_packaging.outputs.value == 'true'
+        run: dotnet pack -p:OutputPath=../../bin/ src/HybridModelBinding
+
       - name: Publish NuGet-package
-        if: env.is_master_branch == 'true' || env.is_release_branch == 'true' || env.is_tag == 'true'
+        if: steps.needs_packaging.outputs.value == 'true'
         run: dotnet nuget push -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_TOKEN}} -n true bin\*.nupkg

--- a/src/HybridModelBinding/HybridModelBinding.csproj
+++ b/src/HybridModelBinding/HybridModelBinding.csproj
@@ -11,8 +11,6 @@
         <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
         <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
         <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-        <VersionPrefix>$(VersionPrefix)</VersionPrefix>
-        <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     </PropertyGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.1" />
@@ -23,4 +21,27 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.8" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
     </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="MinVer" Version="2.0.0">
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
+    </ItemGroup>
+    <Target Name="MinVerPreReleaseCheck" AfterTargets="MinVer" Condition="$(MinVerPreRelease.Split('.').Length) == 3">
+        <PropertyGroup>
+            <MinVerPreReleaseSuffix>$(MinVerPreRelease.Split('.')[2])</MinVerPreReleaseSuffix>
+        </PropertyGroup>
+    </Target>
+    <Target Name="MasterBranchBuild" AfterTargets="MinVerPreReleaseCheck" Condition="$(is_master_branch) == 'true' and $(MinVerPreReleaseSuffix) != ''">
+        <PropertyGroup>
+            <PackageVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)-alpha.$(MinVerPreReleaseSuffix)</PackageVersion>
+            <Version>$(PackageVersion)</Version>
+        </PropertyGroup>
+    </Target>
+    <Target Name="ReleaseBranchBuild" AfterTargets="MinVerPreReleaseCheck" Condition="$(is_release_branch) == 'true' and $(MinVerPreReleaseSuffix) != ''">
+        <PropertyGroup>
+            <PackageVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)-beta.$(MinVerPreReleaseSuffix)</PackageVersion>
+            <Version>$(PackageVersion)</Version>
+        </PropertyGroup>
+    </Target>
 </Project>


### PR DESCRIPTION
Move versioning logic into csproj leveraging `MinVer`.
Remove dependency on build-numbering and only generate GitHub artifacts when publishing.