### PR TITLE
Add parameter bind-ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,17 @@ public IActionResult IndexAlternate(int age, [FromHybrid]IndexModel model)
 { }
 ```
 
+##### FromHybrid
+
+*This attribute is optional if the action only contains one, class-parameter*. When used, however, also has the ability to specify default-ordering when a property is not decorated with `HybridBindProperty`. This will override `FallbackBindingOrder` and `HybridBindClass`. This is useful if an action has different requirements than other actions using the same model:
+
+```csharp
+[HttpGet]
+[Route("{age?}/{name?}")]
+public IActionResult IndexAlternate([FromHybrid(new[] { Source.QueryString, Source.Route })]IndexModel model)
+{ }
+```
+
 #### View
 
 ```html

--- a/src/HybridModelBinding/FromHybridAttribute.cs
+++ b/src/HybridModelBinding/FromHybridAttribute.cs
@@ -3,9 +3,18 @@ using System;
 
 namespace HybridModelBinding
 {
-    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
     public class FromHybridAttribute : Attribute, IBindingSourceMetadata
     {
+        public FromHybridAttribute()
+        { }
+
+        public FromHybridAttribute(string[] defaultBindingOrder)
+        {
+            DefaultBindingOrder = defaultBindingOrder ?? throw new ArgumentNullException(nameof(defaultBindingOrder));
+        }
+
         public BindingSource BindingSource => new HybridBindingSource();
+        public string[] DefaultBindingOrder { get; private set; }
     }
 }

--- a/src/HybridModelBinding/HybridModelBinder.cs
+++ b/src/HybridModelBinding/HybridModelBinder.cs
@@ -1,6 +1,7 @@
 ﻿using HybridModelBinding.Extensions;
 using HybridModelBinding.ModelBinding;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using System;
 using System.Collections;
@@ -150,7 +151,16 @@ namespace HybridModelBinding
                 }
             }
 
-            var defaultBindingOrder = hydratedModel.GetType().GetCustomAttribute<HybridBindClassAttribute>()?.DefaultBindingOrder ?? fallbackBindingOrder;
+            /*
+             * We'll first look if the action-parameter has defined default-ordering.
+             * If nothing is found, we'll look at the model-class.
+             * Lastly, we'll use the fallback.
+             */
+            var defaultBindingOrder = (bindingContext.ActionContext.ActionDescriptor.Parameters
+                .Where(x => x.ParameterType == hydratedModel.GetType()).FirstOrDefault() as ControllerParameterDescriptor)
+                ?.ParameterInfo.GetCustomAttribute<FromHybridAttribute>()?.DefaultBindingOrder
+                ?? hydratedModel.GetType().GetCustomAttribute<HybridBindClassAttribute>()?.DefaultBindingOrder
+                ?? fallbackBindingOrder;
 
             foreach (var property in modelProperties)
             {


### PR DESCRIPTION
New behavior allows specifying bind-ordering when manually associating an action-parameter with hybrid-binding.
This behavior supercedes class-level bind-ordering, but property-level ordering still takes precedence.

Implements https://github.com/billbogaiv/hybrid-model-binding/issues/18