### PR TITLE
Switch from Newtonsoft.Json to System.Text.Json

### DIFF
--- a/src/HybridModelBinding/HybridModelBinding.csproj
+++ b/src/HybridModelBinding/HybridModelBinding.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>Provides the ability to bind models using both ModelBinder and ValueProvider in ASP.NET Core.</Description>
         <Authors>Bill Boga</Authors>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <AssemblyName>HybridModelBinding</AssemblyName>
         <PackageId>HybridModelBinding</PackageId>
         <MinVerMinimumMajorMinor>0.18</MinVerMinimumMajorMinor>
@@ -14,8 +14,8 @@
         <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.1" />
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="MinVer" Version="2.0.0">

--- a/src/HybridModelBinding/HybridModelBinding.csproj
+++ b/src/HybridModelBinding/HybridModelBinding.csproj
@@ -15,7 +15,6 @@
     </PropertyGroup>
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="MinVer" Version="2.0.0">

--- a/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
+++ b/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
@@ -1,11 +1,11 @@
 using HybridModelBinding.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 
 namespace HybridModelBinding.ModelBinding
 {
@@ -33,11 +33,17 @@ namespace HybridModelBinding.ModelBinding
 
             if (!string.IsNullOrEmpty(bodyContent))
             {
-                requestKeys = JObject
-                    .Parse(bodyContent)
-                    .Properties()
-                    .Select(x => x.Name)
-                    .ToArray();
+                using (var document = JsonDocument.Parse(bodyContent))
+                {
+                    if (document.RootElement.ValueKind == JsonValueKind.Object)
+                    {
+                        requestKeys = document
+                            .RootElement
+                            .EnumerateObject()
+                            .Select(p => p.Name)
+                            .ToArray();
+                    }
+                }
             }
 
             foreach (var property in model.GetPropertiesNotPartOfType<IHybridBoundModel>()

--- a/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
+++ b/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
@@ -1,6 +1,5 @@
-﻿using HybridModelBinding.Extensions;
+using HybridModelBinding.Extensions;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json.Linq;
 using System;

--- a/src/HybridModelBinding/ModelBinding/HeaderValueProvider.cs
+++ b/src/HybridModelBinding/ModelBinding/HeaderValueProvider.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
Also switched from the retired `netstandard2.1` (which requires .net core 3 or greater) to `netcoreapp3.1` which supports doing a `FrameworkReference` of `Microsoft.AspNetCore.App`, instead of referencing 3 year old deprecated MVC packages.