### PR TITLE
add Source.Claim

### DIFF
--- a/src/HybridModelBinding/DefaultHybridModelBinder.cs
+++ b/src/HybridModelBinding/DefaultHybridModelBinder.cs
@@ -21,7 +21,8 @@ namespace HybridModelBinding
                 .AddValueProviderFactory(Form, new FormValueProviderFactory())
                 .AddValueProviderFactory(Route, new RouteValueProviderFactory())
                 .AddValueProviderFactory(QueryString, new QueryStringValueProviderFactory())
-                .AddValueProviderFactory(Header, new HeaderValueProviderFactory());
+                .AddValueProviderFactory(Header, new HeaderValueProviderFactory())
+                .AddValueProviderFactory(Claim, new ClaimValueProviderFactory());
         }
     }
 }

--- a/src/HybridModelBinding/DefaultPassthroughHybridModelBinder.cs
+++ b/src/HybridModelBinding/DefaultPassthroughHybridModelBinder.cs
@@ -21,7 +21,8 @@ namespace HybridModelBinding
                 .AddValueProviderFactory(Form, new FormValueProviderFactory())
                 .AddValueProviderFactory(Route, new RouteValueProviderFactory())
                 .AddValueProviderFactory(QueryString, new QueryStringValueProviderFactory())
-                .AddValueProviderFactory(Header, new HeaderValueProviderFactory());
+                .AddValueProviderFactory(Header, new HeaderValueProviderFactory())
+                .AddValueProviderFactory(Claim, new ClaimValueProviderFactory());
         }
     }
 }

--- a/src/HybridModelBinding/HybridModelBinder.cs
+++ b/src/HybridModelBinding/HybridModelBinder.cs
@@ -23,7 +23,7 @@ namespace HybridModelBinding
             this.fallbackBindingOrder = fallbackBindingOrder ?? FallbackBindingOrder;
         }
 
-        protected static IEnumerable<string> FallbackBindingOrder = new[] { Source.Body, Source.Form, Source.Route, Source.QueryString, Source.Header };
+        protected static IEnumerable<string> FallbackBindingOrder = new[] { Source.Body, Source.Form, Source.Route, Source.QueryString, Source.Header, Source.Claim };
 
         private readonly BindStrategy bindStrategy;
         private readonly IEnumerable<string> fallbackBindingOrder;

--- a/src/HybridModelBinding/ModelBinding/ClaimValueProviderFactory.cs
+++ b/src/HybridModelBinding/ModelBinding/ClaimValueProviderFactory.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace HybridModelBinding.ModelBinding
+{
+    public class ClaimValueProviderFactory : IValueProviderFactory
+    {
+        private readonly BindingSource Claim = new BindingSource(
+            "Claim",
+            "BindingSource_Claim",
+            isGreedy: false,
+            isFromRequest: true);
+
+        public Task CreateValueProviderAsync(ValueProviderFactoryContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var claimsPrincipal = context.ActionContext.HttpContext.User;
+            if (claimsPrincipal != null)
+            {
+                var valueProvider = new ClaimValueProvider(
+                    Claim,
+                    claimsPrincipal);
+
+                context.ValueProviders.Add(valueProvider);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    public class ClaimValueProvider : BindingSourceValueProvider
+    {
+        private readonly ClaimsPrincipal _claimsPrincipal;
+
+        public ClaimValueProvider(BindingSource bindingSource, ClaimsPrincipal claimsPrincipal) : base(bindingSource)
+        {
+            _claimsPrincipal = claimsPrincipal;
+        }
+
+        public override bool ContainsPrefix(string prefix) => _claimsPrincipal.HasClaim(claim => claim.Type == prefix);
+
+        public override ValueProviderResult GetValue(string key)
+        {
+            var claim = _claimsPrincipal.FindFirst(key);
+            var claimValue = claim?.Value;
+
+            return claimValue != null ? new ValueProviderResult(claimValue) : ValueProviderResult.None;
+        }
+    }
+}

--- a/src/HybridModelBinding/Source.cs
+++ b/src/HybridModelBinding/Source.cs
@@ -7,5 +7,6 @@
         public const string Header = nameof(Header);
         public const string QueryString = nameof(QueryString);
         public const string Route = nameof(Route);
+        public const string Claim = nameof(Claim);
     }
 }


### PR DESCRIPTION
This small PR adds `Source.Claim`.
This allows binding value from Claim (from cookie or JWT token).
Closes: https://github.com/billbogaiv/hybrid-model-binding/issues/58

If this gets approved I can do a little clean-up of the entire project fixing some Resharper hints.