### PR TITLE
Code cleanup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['3.0', '3.1.x', '5.0.x', '6.0.x' ]
+        dotnet-version: [ '3.1.x', '5.0.x', '6.0.x' ]
     # Steps that run sequentially
     steps:
     

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: .NET Core
+
+# Trigger event
+on:
+  # Run on a push or pull request to default branch (usually master)
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+# Jobs that run in parallel
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: ['3.0', '3.1.x', '5.0.x', '6.0.x' ]
+    # Steps that run sequentially
+    steps:
+      # git checkout repo
+    - uses: actions/checkout@v2
+      # Install dotnet
+    - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+      uses: actions/setup-dotnet@v1.7.2
+      with:
+        dotnet-version: ${{ matrix.dotnet-version }}
+      # Build and run tests
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+    - name: Test
+      run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,4 @@
 name: .NET Core
-
 # Trigger event
 on:
   # Run on a push or pull request to default branch (usually master)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,33 +1,30 @@
 name: .NET Core
-# Trigger event
-on:
-  # Run on a push or pull request to default branch (usually master)
-  push:
-    branches: [ $default-branch ]
-  pull_request:
-    branches: [ $default-branch ]
+# Trigger event on a push or pull request
+on: [push, pull_request]
 
 # Jobs that run in parallel
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         dotnet-version: ['3.0', '3.1.x', '5.0.x', '6.0.x' ]
     # Steps that run sequentially
     steps:
-      # git checkout repo
-    - uses: actions/checkout@v2
-      # Install dotnet
+    
+    - name: Checkout
+      uses: actions/checkout@v2
+      
     - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
       uses: actions/setup-dotnet@v1.7.2
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
-      # Build and run tests
+        
     - name: Install dependencies
       run: dotnet restore
+      
     - name: Build
       run: dotnet build --configuration Release --no-restore
+      
     - name: Test
       run: dotnet test --no-restore --verbosity normal

--- a/src/HybridModelBinding/FromAttribute.cs
+++ b/src/HybridModelBinding/FromAttribute.cs
@@ -3,7 +3,7 @@
 namespace HybridModelBinding
 {
     [Obsolete("Use `" + nameof(HybridBindPropertyAttribute) + "` instead.")]
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class FromAttribute : Attribute
     {
         /// <summary>

--- a/src/HybridModelBinding/FromAttribute.cs
+++ b/src/HybridModelBinding/FromAttribute.cs
@@ -20,7 +20,7 @@ namespace HybridModelBinding
             Strategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
         }
 
-        public HybridModelBinder.BindStrategy Strategy { get; private set; }
-        public string[] ValueProviders { get; private set; }
+        public HybridModelBinder.BindStrategy Strategy { get; }
+        public string[] ValueProviders { get; }
     }
 }

--- a/src/HybridModelBinding/FromHybridAttribute.cs
+++ b/src/HybridModelBinding/FromHybridAttribute.cs
@@ -15,6 +15,6 @@ namespace HybridModelBinding
         }
 
         public BindingSource BindingSource => new HybridBindingSource();
-        public string[] DefaultBindingOrder { get; private set; }
+        public string[] DefaultBindingOrder { get; }
     }
 }

--- a/src/HybridModelBinding/FromHybridAttribute.cs
+++ b/src/HybridModelBinding/FromHybridAttribute.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace HybridModelBinding
 {
-    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Parameter)]
     public class FromHybridAttribute : Attribute, IBindingSourceMetadata
     {
         public FromHybridAttribute()

--- a/src/HybridModelBinding/HybridBindClassAttribute.cs
+++ b/src/HybridModelBinding/HybridBindClassAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace HybridModelBinding
 {
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     public class HybridBindClassAttribute : Attribute
     {
         public HybridBindClassAttribute(string[] defaultBindingOrder)

--- a/src/HybridModelBinding/HybridBindClassAttribute.cs
+++ b/src/HybridModelBinding/HybridBindClassAttribute.cs
@@ -10,6 +10,6 @@ namespace HybridModelBinding
             DefaultBindingOrder = defaultBindingOrder ?? throw new ArgumentNullException(nameof(defaultBindingOrder));
         }
 
-        public string[] DefaultBindingOrder { get; private set; }
+        public string[] DefaultBindingOrder { get; }
     }
 }

--- a/src/HybridModelBinding/HybridBindPropertyAttribute.cs
+++ b/src/HybridModelBinding/HybridBindPropertyAttribute.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace HybridModelBinding
 {
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
     public class HybridBindPropertyAttribute : Attribute
     {
         /// <param name="name">Provide alternate name within `valueProvider` to bind to this property.</param>

--- a/src/HybridModelBinding/HybridBindPropertyAttribute.cs
+++ b/src/HybridModelBinding/HybridBindPropertyAttribute.cs
@@ -10,8 +10,8 @@ namespace HybridModelBinding
         /// <param name="order">Provide explicit order of binding when matched with other usages of `HybridPropertyAttribute` on the same property.</param>
         public HybridBindPropertyAttribute(
             string valueProvider,
-            [CallerMemberName]string name = default(string),
-            [CallerLineNumber]int order = default(int))
+            [CallerMemberName]string name = default,
+            [CallerLineNumber]int order = default)
             : this(new[] { valueProvider }, name, order)
         { }
 
@@ -19,8 +19,8 @@ namespace HybridModelBinding
         /// <param name="order">Provide explicit order of binding when matched with other usages of `HybridPropertyAttribute` on the same property.</param>
         public HybridBindPropertyAttribute(
             string[] valueProviders,
-            [CallerMemberName]string name = default(string),
-            [CallerLineNumber]int order = default(int))
+            [CallerMemberName]string name = default,
+            [CallerLineNumber]int order = default)
         {
             ValueProviders = valueProviders;
             Name = name;
@@ -32,8 +32,8 @@ namespace HybridModelBinding
         protected HybridBindPropertyAttribute(
             HybridModelBinder.BindStrategy strategy,
             string[] valueProviders,
-            [CallerMemberName]string name = default(string),
-            [CallerLineNumber]int order = default(int))
+            [CallerMemberName]string name = default,
+            [CallerLineNumber]int order = default)
             : this(valueProviders, name, order)
         {
             Strategy = strategy ?? throw new ArgumentNullException(nameof(strategy));

--- a/src/HybridModelBinding/HybridBindPropertyAttribute.cs
+++ b/src/HybridModelBinding/HybridBindPropertyAttribute.cs
@@ -39,9 +39,9 @@ namespace HybridModelBinding
             Strategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
         }
 
-        public string Name { get; private set; }
-        public int? Order { get; private set; }
-        public HybridModelBinder.BindStrategy Strategy { get; private set; }
-        public string[] ValueProviders { get; private set; }
+        public string Name { get; }
+        public int? Order { get; }
+        public HybridModelBinder.BindStrategy Strategy { get; }
+        public string[] ValueProviders { get; }
     }
 }

--- a/src/HybridModelBinding/HybridModelBinderApplicationModelConvention.cs
+++ b/src/HybridModelBinding/HybridModelBinderApplicationModelConvention.cs
@@ -18,13 +18,12 @@ namespace HybridModelBinding
                         var parameterModel = action.Parameters.First();
                         var parameterType = parameterModel.ParameterInfo.ParameterType;
                         var hasBindingAttribute = parameterModel.Attributes
-                            .Where(x => typeof(IBindingSourceMetadata).IsAssignableFrom(x.GetType()))
-                            .Any();
+                            .Any(x => typeof(IBindingSourceMetadata).IsAssignableFrom(x.GetType()));
 
                         if (!hasBindingAttribute &&
                             parameterType.IsClass &&
                             !parameterType.IsAbstract &&
-                            parameterType.GetProperties(BindingFlags.Public | BindingFlags.Instance).Count() > 0 &&
+                            parameterType.GetProperties(BindingFlags.Public | BindingFlags.Instance).Any() &&
                             parameterType != typeof(string))
                         {
                             parameterModel.BindingInfo = new BindingInfo()

--- a/src/HybridModelBinding/HybridModelBinderProvider.cs
+++ b/src/HybridModelBinding/HybridModelBinderProvider.cs
@@ -9,34 +9,22 @@ namespace HybridModelBinding
             BindingSource bindingSource,
             IModelBinder modelBinder)
         {
-            if (bindingSource == null)
-            {
-                throw new ArgumentNullException(nameof(bindingSource));
-            }
-
-            if (modelBinder == null)
-            {
-                throw new ArgumentNullException(nameof(modelBinder));
-            }
-
-            this.bindingSource = bindingSource;
-            this.modelBinder = modelBinder;
+            _bindingSource = bindingSource ?? throw new ArgumentNullException(nameof(bindingSource));
+            _modelBinder = modelBinder ?? throw new ArgumentNullException(nameof(modelBinder));
         }
 
-        private BindingSource bindingSource { get; }
-        private IModelBinder modelBinder { get; }
+        private readonly BindingSource _bindingSource; 
+        private readonly IModelBinder _modelBinder; 
 
         public virtual IModelBinder GetBinder(ModelBinderProviderContext context)
         {
             if (context.BindingInfo?.BindingSource != null &&
-                context.BindingInfo.BindingSource.CanAcceptDataFrom(bindingSource))
+                context.BindingInfo.BindingSource.CanAcceptDataFrom(_bindingSource))
             {
-                return modelBinder;
+                return _modelBinder;
             }
-            else
-            {
-                return null;
-            }
+
+            return null;
         }
     }
 }

--- a/src/HybridModelBinding/HybridModelBinderProvider.cs
+++ b/src/HybridModelBinding/HybridModelBinderProvider.cs
@@ -23,8 +23,8 @@ namespace HybridModelBinding
             this.modelBinder = modelBinder;
         }
 
-        private BindingSource bindingSource { get; set; }
-        private IModelBinder modelBinder { get; set; }
+        private BindingSource bindingSource { get; }
+        private IModelBinder modelBinder { get; }
 
         public virtual IModelBinder GetBinder(ModelBinderProviderContext context)
         {

--- a/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
+++ b/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
@@ -44,23 +44,23 @@ namespace HybridModelBinding.ModelBinding
             foreach (var property in model.GetPropertiesNotPartOfType<IHybridBoundModel>()
                 .Where(x => !requestKeys.Any() || requestKeys.Contains(x.Name, StringComparer.OrdinalIgnoreCase)))
             {
-                values.Add(property.Name, property.GetValue(model, null));
+                _values.Add(property.Name, property.GetValue(model, null));
             }
         }
 
-        private PrefixContainer prefixContainer;
-        private IDictionary<string, object> values = new Dictionary<string, object>();
+        private PrefixContainer _prefixContainer;
+        private readonly IDictionary<string, object> _values = new Dictionary<string, object>();
 
         public PrefixContainer PrefixContainer
         {
             get
             {
-                if (prefixContainer == null)
+                if (_prefixContainer == null)
                 {
-                    prefixContainer = new PrefixContainer(values.Keys);
+                    _prefixContainer = new PrefixContainer(_values.Keys);
                 }
 
-                return prefixContainer;
+                return _prefixContainer;
             }
         }
 
@@ -71,8 +71,8 @@ namespace HybridModelBinding.ModelBinding
 
         public object GetObject(string key)
         {
-            return values.ContainsKey(key)
-                ? values[key]
+            return _values.ContainsKey(key)
+                ? _values[key]
                 : null;
         }
 

--- a/src/HybridModelBinding/ModelBinding/ClaimValueProviderFactory.cs
+++ b/src/HybridModelBinding/ModelBinding/ClaimValueProviderFactory.cs
@@ -10,8 +10,8 @@ namespace HybridModelBinding.ModelBinding
         private readonly BindingSource Claim = new BindingSource(
             "Claim",
             "BindingSource_Claim",
-            isGreedy: false,
-            isFromRequest: true);
+            false,
+            true);
 
         public Task CreateValueProviderAsync(ValueProviderFactoryContext context)
         {

--- a/src/HybridModelBinding/ModelBinding/HeaderValueProvider.cs
+++ b/src/HybridModelBinding/ModelBinding/HeaderValueProvider.cs
@@ -23,25 +23,25 @@ namespace HybridModelBinding.ModelBinding
                 throw new ArgumentNullException(nameof(bindingSource));
             }
 
-            this.values = values ?? throw new ArgumentNullException(nameof(values));
+            _values = values ?? throw new ArgumentNullException(nameof(values));
             Culture = culture;
         }
 
         public CultureInfo Culture { get; }
 
-        private readonly IHeaderDictionary values;
-        private PrefixContainer prefixContainer;
+        private readonly IHeaderDictionary _values;
+        private PrefixContainer _prefixContainer;
 
         protected PrefixContainer PrefixContainer
         {
             get
             {
-                if (prefixContainer == null)
+                if (_prefixContainer == null)
                 {
-                    prefixContainer = new PrefixContainer(values.Keys);
+                    _prefixContainer = new PrefixContainer(_values.Keys);
                 }
 
-                return prefixContainer;
+                return _prefixContainer;
             }
         }
 
@@ -67,16 +67,14 @@ namespace HybridModelBinding.ModelBinding
                 throw new ArgumentNullException(nameof(key));
             }
 
-            var values = this.values[key];
+            var values = _values[key];
 
             if (values.Count == 0)
             {
                 return ValueProviderResult.None;
             }
-            else
-            {
-                return new ValueProviderResult(values, Culture);
-            }
+
+            return new ValueProviderResult(values, Culture);
         }
     }
 }

--- a/src/HybridModelBinding/ModelBinding/HeaderValueProvider.cs
+++ b/src/HybridModelBinding/ModelBinding/HeaderValueProvider.cs
@@ -27,7 +27,7 @@ namespace HybridModelBinding.ModelBinding
             Culture = culture;
         }
 
-        public CultureInfo Culture { get; private set; }
+        public CultureInfo Culture { get; }
 
         private readonly IHeaderDictionary values;
         private PrefixContainer prefixContainer;

--- a/src/HybridModelBinding/ModelBinding/HeaderValueProviderFactory.cs
+++ b/src/HybridModelBinding/ModelBinding/HeaderValueProviderFactory.cs
@@ -13,13 +13,14 @@ namespace HybridModelBinding.ModelBinding
         /// 
         /// Ref. https://github.com/aspnet/Mvc/blob/8d66f104f7f2ca42ee8b21f75b0e2b3e1abe2e00/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/BindingSource.cs
         /// Ref. https://github.com/aspnet/Mvc/blob/8d66f104f7f2ca42ee8b21f75b0e2b3e1abe2e00/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/BindingSourceValueProvider.cs#L41
-        /// ArgumentException: The provided binding source 'Header' is a greedy data source. 'BindingSourceValueProvider' does not support greedy data sources.        /// Parameter name: bindingSource
+        /// ArgumentException: The provided binding source 'Header' is a greedy data source. 'BindingSourceValueProvider' does not support greedy data sources.
+        /// Parameter name: bindingSource
         /// </summary>
         private BindingSource Header = new BindingSource(
             BindingSource.Header.Id,
             BindingSource.Header.DisplayName,
-            isGreedy: false,
-            isFromRequest: BindingSource.Header.IsFromRequest);
+            false,
+            BindingSource.Header.IsFromRequest);
 
         public Task CreateValueProviderAsync(ValueProviderFactoryContext context)
         {


### PR DESCRIPTION
some cleanup that was suggested by Resharper.

Things to consider (probably in the next PR).

Should I replace
```
var hasBindingAttribute = parameterModel.Attributes
    .Any(x => typeof(IBindingSourceMetadata).IsAssignableFrom(x.GetType()));
```
with
```
var hasBindingAttribute = parameterModel.Attributes
    .Any(x => x is IBindingSourceMetadata);
```
and other similar places?
Also, VS2022 is suggesting many improvements, especially with LINQ.
It would be easier to do such fixes if we had some tests.
But maybe we can figure something out :)