### PR TITLE
Support JsonPropertyName and JsonProperty attributes when binding from body

### DIFF
--- a/samples/AspNetCoreWebApplication/AspNetCoreWebApplication.csproj
+++ b/samples/AspNetCoreWebApplication/AspNetCoreWebApplication.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.23" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/AspNetCoreWebApplication/Controllers/DataController.cs
+++ b/samples/AspNetCoreWebApplication/Controllers/DataController.cs
@@ -1,0 +1,31 @@
+﻿using System.Text.Json.Serialization;
+using HybridModelBinding;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+
+namespace AspNetCoreWebApplication.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class DataController : ControllerBase
+    {
+        [HttpPost]
+        public ActionResult<string> Index(DataModel model)
+        {
+            return $"{model.Name} - {model.IsAdmin}";
+        }
+    }
+
+    public class DataModel
+    {
+        [HybridBindProperty(Source.Body)]
+        public string Name { get; set; }
+
+        [HybridBindProperty(Source.Body)]
+        [JsonPropertyName("is_admin"), JsonProperty("is_admin")]
+        public bool IsAdmin { get; set; }
+
+        [HybridBindProperty(Source.Header, "X-UserId")]
+        public int UserId { get; set; }
+    }
+}

--- a/samples/AspNetCoreWebApplication/Startup.cs
+++ b/samples/AspNetCoreWebApplication/Startup.cs
@@ -10,7 +10,8 @@ namespace AspNetCoreWebApplication
         {
             services
                 .AddMvc()
-                .AddHybridModelBinder();
+                .AddHybridModelBinder()
+                .AddNewtonsoftJson();
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
@@ -27,10 +28,7 @@ namespace AspNetCoreWebApplication
             app.UseStaticFiles();
 
             app.UseRouting();
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapControllers();
-            });
+            app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
         }
     }
 }

--- a/src/HybridModelBinding/Extensions/PropertyInfoExtensions.cs
+++ b/src/HybridModelBinding/Extensions/PropertyInfoExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System.Reflection;
+using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+
+namespace HybridModelBinding.Extensions
+{
+    public static class PropertyInfoExtensions
+    {
+        public static string GetNameFromAttributes(this PropertyInfo propertyInfo)
+        {
+            //default value
+            var name = propertyInfo.Name;
+
+            //newtonsoft.json
+            var jsonPropertyAttribute = propertyInfo.GetCustomAttribute<JsonPropertyAttribute>();
+            if (jsonPropertyAttribute != null)
+            {
+                return jsonPropertyAttribute.PropertyName;
+            }
+            //system.text.json
+            var jsonPropertyNameAttribute = propertyInfo.GetCustomAttribute<JsonPropertyNameAttribute>();
+            if (jsonPropertyNameAttribute != null)
+            {
+                return jsonPropertyNameAttribute.Name;
+            }
+
+            return name;
+        }
+    }
+}

--- a/src/HybridModelBinding/HybridModelBinding.csproj
+++ b/src/HybridModelBinding/HybridModelBinding.csproj
@@ -22,6 +22,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
+      <PackageReference Include="System.Text.Json" Version="6.0.2" />
     </ItemGroup>
     <Target Name="MinVerPreReleaseCheck" AfterTargets="MinVer" Condition="$(MinVerPreRelease.Split('.').Length) == 3">
         <PropertyGroup>

--- a/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
+++ b/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
@@ -41,10 +41,13 @@ namespace HybridModelBinding.ModelBinding
                     .ToArray();
             }
 
-            foreach (var property in model.GetPropertiesNotPartOfType<IHybridBoundModel>()
-                .Where(x => !requestKeys.Any() || requestKeys.Contains(x.Name, StringComparer.OrdinalIgnoreCase)))
+            foreach (var property in model.GetPropertiesNotPartOfType<IHybridBoundModel>())
             {
-                values.Add(property.Name, property.GetValue(model, null));
+                var propertyName = property.GetNameFromAttributes();
+                if (!requestKeys.Any() || requestKeys.Contains(propertyName, StringComparer.OrdinalIgnoreCase))
+                {
+                    values.Add(property.Name, property.GetValue(model, null));
+                }
             }
         }
 


### PR DESCRIPTION
This change allows binding to properties that have `JsonPropertyName` or `JsonProperty`.
I've also adjusted the sample to show the new behavior.
Tested locally with both Test.Json and Newtonsoft.Json

Closes https://github.com/billbogaiv/hybrid-model-binding/issues/61