### PR TITLE
Separate target for netcoreapp

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.100'
+          dotnet-version: '3.1.x'
 
       - name: Build project
         run: dotnet build -c Release src/HybridModelBinding

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,12 +27,12 @@ jobs:
           dotnet-version: '3.1.100'
 
       - name: Build project
-        run: dotnet build -c Release -f netstandard2.1 -o bin/ src/HybridModelBinding
+        run: dotnet build -c Release src/HybridModelBinding
 
       - name: Create NuGet-package
         if: steps.needs_packaging.outputs.value == 'true'
-        run: dotnet pack --no-build -p:OutputPath=../../bin/ src/HybridModelBinding
+        run: dotnet pack --no-build src/HybridModelBinding
 
       - name: Publish NuGet-package
         if: steps.needs_packaging.outputs.value == 'true'
-        run: dotnet nuget push -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_TOKEN}} -n true bin\*.nupkg
+        run: dotnet nuget push -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_TOKEN}} -n true src/HybridModelBinding/bin/*.nupkg

--- a/src/HybridModelBinding/HybridModelBinding.csproj
+++ b/src/HybridModelBinding/HybridModelBinding.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>Provides the ability to bind models using both ModelBinder and ValueProvider in ASP.NET Core.</Description>
         <Authors>Bill Boga</Authors>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
         <AssemblyName>HybridModelBinding</AssemblyName>
         <PackageId>HybridModelBinding</PackageId>
         <MinVerMinimumMajorMinor>0.18</MinVerMinimumMajorMinor>
@@ -12,10 +12,15 @@
         <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
         <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
         <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+        <UserSecretsId>56b9ce4e-e8a6-4bdd-93ea-2e005b3cdb87</UserSecretsId>
     </PropertyGroup>
-    <ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.1" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.1" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="MinVer" Version="2.0.0">

--- a/src/HybridModelBinding/HybridModelBinding.csproj
+++ b/src/HybridModelBinding/HybridModelBinding.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>Provides the ability to bind models using both ModelBinder and ValueProvider in ASP.NET Core.</Description>
         <Authors>Bill Boga</Authors>
-        <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;netstandard2.1</TargetFrameworks>
         <AssemblyName>HybridModelBinding</AssemblyName>
         <PackageId>HybridModelBinding</PackageId>
         <MinVerMinimumMajorMinor>0.18</MinVerMinimumMajorMinor>
@@ -18,7 +18,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.1" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.1" />
     </ItemGroup>
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>

--- a/src/HybridModelBinding/HybridModelBinding.csproj
+++ b/src/HybridModelBinding/HybridModelBinding.csproj
@@ -17,6 +17,7 @@
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.1" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.34" />
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
         <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
+++ b/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
@@ -1,6 +1,6 @@
 ﻿using HybridModelBinding.Extensions;
 using Microsoft.AspNetCore.Http;
-#if (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1)
+#if (NETSTANDARD)
 using Microsoft.AspNetCore.Mvc.Internal;
 #endif
 using Microsoft.AspNetCore.Mvc.ModelBinding;

--- a/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
+++ b/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
@@ -1,6 +1,6 @@
 ﻿using HybridModelBinding.Extensions;
 using Microsoft.AspNetCore.Http;
-#if NETSTANDARD2_1_OR_GREATER
+#if (NETSTANDARD2_1_OR_GREATER || NETCORAPP3_1)
 using Microsoft.AspNetCore.Mvc.Internal;
 #endif
 using Microsoft.AspNetCore.Mvc.ModelBinding;

--- a/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
+++ b/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
@@ -1,6 +1,6 @@
 ﻿using HybridModelBinding.Extensions;
 using Microsoft.AspNetCore.Http;
-#if (NETSTANDARD)
+#if NETSTANDARD
 using Microsoft.AspNetCore.Mvc.Internal;
 #endif
 using Microsoft.AspNetCore.Mvc.ModelBinding;

--- a/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
+++ b/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
@@ -1,6 +1,6 @@
 ﻿using HybridModelBinding.Extensions;
 using Microsoft.AspNetCore.Http;
-#if (NETSTANDARD2_1_OR_GREATER || NETCORAPP3_1)
+#if (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1)
 using Microsoft.AspNetCore.Mvc.Internal;
 #endif
 using Microsoft.AspNetCore.Mvc.ModelBinding;

--- a/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
+++ b/src/HybridModelBinding/ModelBinding/BodyValueProvider.cs
@@ -1,6 +1,8 @@
 ﻿using HybridModelBinding.Extensions;
 using Microsoft.AspNetCore.Http;
+#if NETSTANDARD2_1_OR_GREATER
 using Microsoft.AspNetCore.Mvc.Internal;
+#endif
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json.Linq;
 using System;

--- a/src/HybridModelBinding/ModelBinding/HeaderValueProvider.cs
+++ b/src/HybridModelBinding/ModelBinding/HeaderValueProvider.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
-#if (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1)
+#if (NETSTANDARD)
 using Microsoft.AspNetCore.Mvc.Internal;
 #endif
 using Microsoft.AspNetCore.Mvc.ModelBinding;

--- a/src/HybridModelBinding/ModelBinding/HeaderValueProvider.cs
+++ b/src/HybridModelBinding/ModelBinding/HeaderValueProvider.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
-#if (NETSTANDARD)
+#if NETSTANDARD
 using Microsoft.AspNetCore.Mvc.Internal;
 #endif
 using Microsoft.AspNetCore.Mvc.ModelBinding;

--- a/src/HybridModelBinding/ModelBinding/HeaderValueProvider.cs
+++ b/src/HybridModelBinding/ModelBinding/HeaderValueProvider.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
+#if NETSTANDARD2_1_OR_GREATER
 using Microsoft.AspNetCore.Mvc.Internal;
+#endif
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using System;
 using System.Collections.Generic;

--- a/src/HybridModelBinding/ModelBinding/HeaderValueProvider.cs
+++ b/src/HybridModelBinding/ModelBinding/HeaderValueProvider.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
-#if (NETSTANDARD2_1_OR_GREATER || NETCORAPP3_1)
+#if (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1)
 using Microsoft.AspNetCore.Mvc.Internal;
 #endif
 using Microsoft.AspNetCore.Mvc.ModelBinding;

--- a/src/HybridModelBinding/ModelBinding/HeaderValueProvider.cs
+++ b/src/HybridModelBinding/ModelBinding/HeaderValueProvider.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
-#if NETSTANDARD2_1_OR_GREATER
+#if (NETSTANDARD2_1_OR_GREATER || NETCORAPP3_1)
 using Microsoft.AspNetCore.Mvc.Internal;
 #endif
 using Microsoft.AspNetCore.Mvc.ModelBinding;


### PR DESCRIPTION
Adds support for targeting .netcoreapp3.1 (and later .NETs) which allows to avoid referencing `Microsoft.AspNetCore.*` packages that are no longer maintained. Relevant classes are consumed from dotnet runtime instead using the framework reference

bumped `Microsoft.AspNetCore.Http` since currently referenced version [is reported to have a severe vulnerability](https://www.nuget.org/packages/Microsoft.AspNetCore.Http/2.1.0) by Nuget;
bumped `NewtonSoft.Json` for [the same reason](https://www.nuget.org/packages/Newtonsoft.Json/9.0.1)